### PR TITLE
Remove `TypeAlias` import workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ src = ["src"]
 target-version = "py38"
 
 [tool.ruff.lint]
-typing-modules = ["_compat"]
+typing-modules = ["jsonlogic._compat"]
 preview = true
 explicit-preview-rules = true
 select = [

--- a/src/jsonlogic/core.py
+++ b/src/jsonlogic/core.py
@@ -13,9 +13,6 @@ from .json_schema.types import AnyType, JSONSchemaType
 from .typing import JSON, JSONLogicPrimitive, JSONObject, OperatorArgument
 
 if TYPE_CHECKING:
-    # This is a hack to make Pylance think `TypeAlias` comes from `typing`
-    from typing import TypeAlias
-
     from .evaluation import EvaluationContext
     from .registry import OperatorRegistry
     from .typechecking import TypecheckContext

--- a/src/jsonlogic/typing.py
+++ b/src/jsonlogic/typing.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING
 from ._compat import TypeAlias
 
 if TYPE_CHECKING:
-    # This is a hack to make Pylance think `TypeAlias` comes from `typing`
-    from typing import TypeAlias
-
     from jsonlogic.core import Operator
 
 JSONPrimitive: TypeAlias = "str | int | float | bool | None"


### PR DESCRIPTION
pyright now seems to understand the `_compat` import properly.