### PR TITLE
Rename `UnkownOperator` to `UnknownOperator`

### DIFF
--- a/src/jsonlogic/registry.py
+++ b/src/jsonlogic/registry.py
@@ -9,7 +9,6 @@ from ._compat import Self, TypeAlias
 from .core import Operator
 
 
-
 class AlreadyRegistered(Exception):
     """The provided ID is already registered."""
 

--- a/src/jsonlogic/registry.py
+++ b/src/jsonlogic/registry.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from typing import Callable, Type, TypeVar, overload
+import warnings
 
 from ._compat import Self, TypeAlias
 from .core import Operator
+
 
 
 class AlreadyRegistered(Exception):
@@ -15,11 +17,21 @@ class AlreadyRegistered(Exception):
         self.operator_id = operator_id
 
 
-class UnkownOperator(Exception):
+class UnknownOperator(Exception):
     """The provided ID does not exist in the registry."""
 
     def __init__(self, operator_id: str, /) -> None:
         self.operator_id = operator_id
+
+class UnkownOperator(UnknownOperator):
+    def __init__(self, operator_id: str, /):
+        warnings.warn(
+            "UnkownOperator is deprecated and will be removed in a future release. "
+            "Please use UnknownOperator instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        super().__init__(operator_id)
 
 
 OperatorType: TypeAlias = Type[Operator]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -53,13 +53,17 @@ def test_force():
     assert registry.get("var") is Var2
 
 
-def test_get_unknown():
+def test_get_unknown(recwarn):
     registry = OperatorRegistry()
 
     with pytest.raises(UnkownOperator) as exc:
         registry.get("unknown")
 
     assert exc.value.operator_id == "unknown"
+
+    warning = recwarn.pop()
+    assert issubclass(warning.category, DeprecationWarning)
+    assert "UnkownOperator is deprecated and will be removed" in str(warning.message)
 
 
 def test_remove():


### PR DESCRIPTION
There's a typo in the `UnkownOperator`. I added the `UnknownOperator`, and made the old typo version inherit from that for backward compatibility. The old version can still be used, but gives a warning. The test now checks that this warning is given.

In a new version, the `UnkownOperator` can be remove entirely.