### PR TITLE
Rename `UnkownOperator` to `UnknownOperator`

### DIFF
--- a/src/jsonlogic/registry.py
+++ b/src/jsonlogic/registry.py
@@ -16,7 +16,7 @@ class AlreadyRegistered(Exception):
         self.operator_id = operator_id
 
 
-class UnkownOperator(Exception):
+class UnknownOperator(Exception):
     """The provided ID does not exist in the registry."""
 
     def __init__(self, operator_id: str, /) -> None:
@@ -42,7 +42,7 @@ class OperatorRegistry:
         >>> reg.get("unknown")
         Traceback (most recent call last):
         ...
-        UnkownOperator: "unknown"
+        UnknownOperator: "unknown"
     """
 
     def __init__(self) -> None:
@@ -102,12 +102,12 @@ class OperatorRegistry:
             operator_id: The registered ID of the operator.
 
         Raises:
-            UnkownOperator: If the provided ID does not exist.
+            UnknownOperator: If the provided ID does not exist.
         """
         try:
             return self._registry[operator_id]
         except KeyError:
-            raise UnkownOperator(operator_id)  # noqa: B904
+            raise UnknownOperator(operator_id)  # noqa: B904
 
     def remove(self, operator_id: str, /) -> None:
         """Remove the operator from the registry.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,7 @@
 import pytest
 
 from jsonlogic.core import Operator
-from jsonlogic.registry import AlreadyRegistered, OperatorRegistry, UnkownOperator
+from jsonlogic.registry import AlreadyRegistered, OperatorRegistry, UnknownOperator
 
 
 def test_operator_registry():
@@ -56,7 +56,7 @@ def test_force():
 def test_get_unknown():
     registry = OperatorRegistry()
 
-    with pytest.raises(UnkownOperator) as exc:
+    with pytest.raises(UnknownOperator) as exc:
         registry.get("unknown")
 
     assert exc.value.operator_id == "unknown"


### PR DESCRIPTION
Replaces https://github.com/Viicos/jsonlogic/pull/36.